### PR TITLE
Add document in context to validationDidStart

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -75,6 +75,12 @@ func Do(p Params) *Result {
 		}
 	}
 
+	if p.Context == nil {
+		p.Context = context.Background()
+	}
+
+	p.Context = WithDocument(p.Context, AST)
+
 	// notify extensions about the start of the validation
 	extErrs, validationFinishFn := handleExtensionsValidationDidStart(&p)
 	if len(extErrs) != 0 {

--- a/validator.go
+++ b/validator.go
@@ -1,11 +1,27 @@
 package graphql
 
 import (
+	"context"
+
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/kinds"
 	"github.com/graphql-go/graphql/language/visitor"
 )
+
+type contextKey int
+
+const (
+	documentKey contextKey = iota
+)
+
+func WithDocument(ctx context.Context, astDoc *ast.Document) context.Context {
+	return context.WithValue(ctx, documentKey, astDoc)
+}
+
+func GetDocument(ctx context.Context) *ast.Document {
+	return ctx.Value(documentKey).(*ast.Document)
+}
 
 type ValidationResult struct {
 	IsValid bool


### PR DESCRIPTION
According to [Apollo](https://www.apollographql.com/docs/apollo-server/integrations/plugins-event-reference/#validationdidstart), the parsed AST should be available during the `validationDidStart` step in extensions.